### PR TITLE
api_monitor updated

### DIFF
--- a/app/models/api_monitor.rb
+++ b/app/models/api_monitor.rb
@@ -1,4 +1,4 @@
-class ApiMonitor
+class ApiMonitor < ActiveRecord::Base
   def self.fetch_stories
     stories = new_stories
     return false if stories.size == 0
@@ -11,7 +11,6 @@ class ApiMonitor
       response = client.get_item(item)
       response if response.type == 'story'
     end.compact
-    self.last_max= @@max
     stories
   end
 
@@ -30,17 +29,11 @@ class ApiMonitor
   end
 
   def self.max
-    @@max = client.max_item.to_i
+    ApiMonitor.create(hn_id: client.max_item.to_i).hn_id
   end
 
   def self.last_max
-    return ENV['API_MONITOR_LAST_MAX'].to_i unless ENV['API_MONITOR_LAST_MAX'].nil?
-    ENV['API_MONITOR_LAST_MAX'] = client.max_item
-    ENV['API_MONITOR_LAST_MAX'].to_i
-  end
-
-  def self.last_max= new_value
-    ENV['API_MONITOR_LAST_MAX'] = new_value.to_s
-    return
+    return ApiMonitor.order(hn_id: :desc).limit(1).first.hn_id unless ApiMonitor.count == 0
+    max
   end
 end

--- a/db/migrate/20150130192608_create_api_monitor.rb
+++ b/db/migrate/20150130192608_create_api_monitor.rb
@@ -1,0 +1,8 @@
+class CreateApiMonitor < ActiveRecord::Migration
+  def change
+    create_table :api_monitors do |t|
+      t.integer :hn_id
+    end
+    add_index :api_monitors, :hn_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150128183742) do
+ActiveRecord::Schema.define(version: 20150130192608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "api_monitors", force: true do |t|
+    t.integer "hn_id"
+  end
+
+  add_index "api_monitors", ["hn_id"], name: "index_api_monitors_on_hn_id", using: :btree
 
   create_table "stories", force: true do |t|
     t.string   "title"

--- a/spec/models/api_monitor_spec.rb
+++ b/spec/models/api_monitor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ApiMonitor do
   before(:each) do
-    ENV['API_MONITOR_LAST_MAX'] = '8863'
+    ApiMonitor.create(hn_id: 8863)
   end
 
   context 'with no new items' do
@@ -32,7 +32,7 @@ describe ApiMonitor do
   context 'with new items available' do
     let(:items) { ApiMonitor.new_stories }  
     before(:each) do
-      ENV['API_MONITOR_LAST_MAX'] = '8863'
+      ApiMonitor.create(hn_id: 8863)
       allow(ApiMonitor.client).to receive(:max_item).and_return('8867')
       story = instance_double(Story)
       allow(Story).to receive(:create).and_return(story)
@@ -76,10 +76,5 @@ describe ApiMonitor do
     it { expect(ApiMonitor.last_max).to eq 8863 }
   end
 
-  describe '.last_max=' do
-    it 'sets the last_max' do
-      expect{ ApiMonitor.last_max = '1234'}.to change {ApiMonitor.last_max}.from(8863).to(1234)
-    end
-  end
 end
 


### PR DESCRIPTION
ENV[''] = doesn't work as I expected. Fixed with a database table.